### PR TITLE
[fix/visual] 높은 해상도 디바이스에서 비주얼 배경 위치 조정

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -170,7 +170,7 @@ body {
 	position: relative;
 	background: url("../src/assets/visual_bg.jpg") no-repeat;
 	background-attachment: fixed;
-	background-position: center;
+	background-position: top center;
 }
 .visual .container::before {
 	content: "";


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 해상도가 높은 디바이스에서 비주얼 배경이 아래로 내려와 빈 공간이 생기는 현상을 발견했습니다. 이를 수정하여 반영합니다.

# 느낀 점 및 어려운 점
- 큰 화면에서 보다 발견했습니다. 다행입니다.

# [option] 관련 알림사항
-