### PR TITLE
[fix/ogImage] 공유 이미지 경로 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
-# dist
+dist
 dist-ssr
 *.local
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 	<meta property="og:title" content="신나현의 포트폴리오 사이트" />
 	<meta property="og:url" content="https://shinnh2.github.io/portfolio_snh/" />
 	<meta property="og:type" content="website" />
-	<meta property="og:image" content="/og_image_snh.jpg" />
+	<meta property="og:image" content="https://shinnh2.github.io/portfolio_snh/og_image_snh.jpg" />
 	<meta property="og:description" content="프론트엔드 개발이 가능한 퍼블리셔 신나현의 포트폴리오 사이트입니다." />
 	<link rel="icon" type="image/svg+xml" href="/favicon_snh.png" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
# PR 종류 (중복 체크 가능)
- [ ]  Refactor
- [ ]  Feature
- [x]  Bug Fix
- [ ]  Optimization
- [ ]  Documentation Update

# 설명
- 공유 이미지 절대경로로 변경
- gitignore 파일에서 dist 폴더 숨김으로 변경

# 느낀 점 및 어려운 점
- 공유 이미지가 사이트 주소 공유시 보이지 않아 수정합니다.
- gitignore에서 dist를 숨김으로 처리했습니다. 배포할 때마다 dev에 현행화할 필요는 없을 것 같습니다.

# [option] 관련 알림사항
해당 작업과 관련된 알림사항 등을 선택적으로 입력합니다.
